### PR TITLE
Add pipe format and support sort by birthdate

### DIFF
--- a/code-exercise/spec/fixtures/people_by_pipe.txt
+++ b/code-exercise/spec/fixtures/people_by_pipe.txt
@@ -1,3 +1,3 @@
-birthdate % first_name % city
+birthdate | first_name | city
 10.24.1990 | Joseph | New York City
 1.15.1995 | Jane | Denver

--- a/code-exercise/spec/fixtures/people_by_pipe.txt
+++ b/code-exercise/spec/fixtures/people_by_pipe.txt
@@ -1,0 +1,3 @@
+birthdate % first_name % city
+10.24.1990 | Joseph | New York City
+1.15.1995 | Jane | Denver

--- a/code-exercise/spec/functional/app_spec.rb
+++ b/code-exercise/spec/functional/app_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'App Functional Test' do
       {
         dollar_format: File.read('spec/fixtures/people_by_dollar.txt'),
         percent_format: File.read('spec/fixtures/people_by_percent.txt'),
-        order: :first_name,
+        order: :name,
       }
     end
     let(:people_controller) { PeopleController.new(params) }
@@ -23,6 +23,32 @@ RSpec.describe 'App Functional Test' do
         'Mckayla, Atlanta, 5/29/1986',
         'Rhiannon, Los Angeles, 4/30/1974',
         'Rigoberto, New York City, 1/5/1962',
+      ]
+    end
+  end
+
+  describe 'dollar, percent and pipe formats sorted by birthdate' do
+    let(:params) do
+      {
+        dollar_format: File.read('spec/fixtures/people_by_dollar.txt'),
+        percent_format: File.read('spec/fixtures/people_by_percent.txt'),
+        pipe_format: File.read('spec/fixtures/people_by_pipe.txt'),
+        order: :birthdate,
+      }
+    end
+    let(:people_controller) { PeopleController.new(params) }
+
+    it 'parses input files and outputs normalized data' do
+      normalized_people = people_controller.normalize
+
+      # Expected format of each entry: `<first_name>, <city>, <birthdate M/D/YYYY>`
+      expect(normalized_people).to eq [
+        'Elliot, New York City, 5/4/1947',
+        'Rigoberto, New York City, 1/5/1962',
+        'Rhiannon, Los Angeles, 4/30/1974',
+        'Mckayla, Atlanta, 5/29/1986',
+        'Joseph, New York City, 10/24/1990',
+        'Jane, Denver, 1/15/1995',
       ]
     end
   end

--- a/code-exercise/spec/functional/app_spec.rb
+++ b/code-exercise/spec/functional/app_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'App Functional Test' do
       {
         dollar_format: File.read('spec/fixtures/people_by_dollar.txt'),
         percent_format: File.read('spec/fixtures/people_by_percent.txt'),
-        order: :name,
+        order: :first_name,
       }
     end
     let(:people_controller) { PeopleController.new(params) }


### PR DESCRIPTION
# Extension Exercise

### Task:

- Checkout the branch of this PR
- Parse the new input format: people data split by pipe - see the added fixture for details
- Combine the entries from the different formats
- Add support to sort the entries by `birthdate`
- Format each entry to `<first_name>, <city>, <birth_date M/D/YYYY>` **(same as before)**
- Write at least 1 spec